### PR TITLE
fix:variable referenced before assignment

### DIFF
--- a/src/layers.py
+++ b/src/layers.py
@@ -540,7 +540,7 @@ class LayerPool:
         for l in self.layers:
             covered_spool.extend(l.superitems_pool)
 
-        return [s for s in self.superitems_pool if not covered_spool.get_index(s)]
+        return [s for s in self.superitems_pool if covered_spool.get_index(s) is None]
 
     def get_heights(self):
         """

--- a/src/maxrects.py
+++ b/src/maxrects.py
@@ -21,6 +21,7 @@ def maxrects_multiple_layers(superitems_pool, pallet_dims, add_single=True):
     # Return a layer with a single item if only one is present in the superitems pool
     if len(superitems_pool) == 1:
         layer_pool = layers.LayerPool(superitems_pool, pallet_dims, add_single=True)
+        uncovered = 1
     else:
         generated_pools = []
         for strategy in MAXRECTS_PACKING_STRATEGIES:

--- a/src/maxrects.py
+++ b/src/maxrects.py
@@ -21,7 +21,7 @@ def maxrects_multiple_layers(superitems_pool, pallet_dims, add_single=True):
     # Return a layer with a single item if only one is present in the superitems pool
     if len(superitems_pool) == 1:
         layer_pool = layers.LayerPool(superitems_pool, pallet_dims, add_single=True)
-        uncovered = 1
+        uncovered = 0
     else:
         generated_pools = []
         for strategy in MAXRECTS_PACKING_STRATEGIES:


### PR DESCRIPTION
variable 'uncovered' referenced before assignment if only one superitems_pool